### PR TITLE
Fix V773 warning from PVS-Studio Static Analyzer

### DIFF
--- a/pyxmeans/c_minibatch/minibatch.c
+++ b/pyxmeans/c_minibatch/minibatch.c
@@ -333,6 +333,7 @@ void minibatch(double *data, double *centroids, int n_samples, int max_iter, dou
     free(centroid_counts);
     free(sample_indicies);
     free(cluster_cache);
+    free(last_centroid_counts);
 
     if (bic_ratio_termination > 0.0) {
         free(historical_bic);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Visibility scope of the 'last_centroid_counts' pointer was exited
without releasing the memory. A memory leak is possible.